### PR TITLE
Added accessibility string which can be built alongside the attributed string

### DIFF
--- a/AttributedStringBuilder/AttributedStringBuilder/AttributedStringBuilder.swift
+++ b/AttributedStringBuilder/AttributedStringBuilder/AttributedStringBuilder.swift
@@ -130,8 +130,10 @@ public class AttributedStringBuilder {
     // MARK: - Properties
 
     private var masterAttributedString = NSMutableAttributedString()
+    private var masterAccessibilityStrings: [String] = []
     
     public var attributedString: NSAttributedString {
+        masterAttributedString.accessibilityLabel = masterAccessibilityStrings.joined(separator: ", ")
         return masterAttributedString
     }
     
@@ -147,17 +149,22 @@ public class AttributedStringBuilder {
     
     public init() {}
     
-    @discardableResult public func text(_ string: String, attributes: [Attribute] = []) -> AttributedStringBuilder {
+    @discardableResult public func text(_ string: String, attributes: [Attribute] = [], accessibilityString: String? = nil) -> AttributedStringBuilder {
         
         let attributes = attributesDictionary(withOverrides: attributes)
         let attributedString = NSAttributedString(string: string, attributes: attributes)
+
         masterAttributedString.append(attributedString)
+        masterAccessibilityStrings.append(accessibilityString ?? string)
+
         return self
     }
     
-    @discardableResult public func attributedText(_ attributedString: NSAttributedString) -> AttributedStringBuilder {
+    @discardableResult public func attributedText(_ attributedString: NSAttributedString, accessibilityString: String? = nil) -> AttributedStringBuilder {
         
         masterAttributedString.append(attributedString)
+        masterAccessibilityStrings.append(accessibilityString ?? attributedString.string)
+        
         return self
     }
     


### PR DESCRIPTION
Building attributed strings with accessibility in mind is not as straightforward as it could be. Instead of having to use an array alongside the building of an attributed string using this builder, the attributed string could be passed as an optional parameter. These could then be joined and assigned to the accessibilityLabel of the attributed string when accessing the attributed string through the computed property.

This makes it easier to build accessible attributed strings, especially when there's lots of logic which impacts which strings are added to the attributedString e.g.:

An attributed string made up of two parts "10-20 mins" and "6.4 miles", with the accessibiliityLabel "Delivery time is 10-20 mins, distance is 6.4 miles" would require:
```
let builder = AttributedStringBuilder()
let accessibilityStrings: [String] = []
build.text("10-20 mins")
accessibilityStrings.append("Delivery time is 10-20 mins")
build.text("6.4 miles")
accessibilityStrings.append("Distance is 6.4 miles")

let attributedString = builder.attributedString
attributedString.accessibilityLabel = accessibilityStrings.joined(separator: " , ")
```

With this change it'd look like this:
```
let builder = AttributedStringBuilder()
builder.text("10-20 mins", accessibilityString: "Delivery time is 10-20 mins")
builder.text("6.4 miles", accessibilityString: "Distance is 6.4 miles")
let attributedString = builder.attributedString
```